### PR TITLE
Fix undefined behavior for non-POD type T

### DIFF
--- a/ArrayTypes.h
+++ b/ArrayTypes.h
@@ -154,6 +154,40 @@ public:
 	void replace(It begin, It end) { base_type::replace(begin, end); std::sort(base_type::begin(), base_type::end()); }
 };
 
+template<class KeyT, class ValueT>
+class ArrayMultiMap : public ArrayMap<KeyT, ValueT>
+{
+public:
+	using typename ArrayMap<KeyT, ValueT>::value_type;
+	using typename ArrayMap<KeyT, ValueT>::base_type;
+	using typename ArrayMap<KeyT, ValueT>::iterator;
+	using typename ArrayMap<KeyT, ValueT>::const_iterator;
+	using ArrayMap<KeyT, ValueT>::find;
+	using ArrayMap<KeyT, ValueT>::clear;
+	using ArrayMap<KeyT, ValueT>::at;
+	using ArrayMap<KeyT, ValueT>::operator[];
+
+	template<class TContainer>  ArrayMultiMap(TContainer &container)    			: ArrayMap<KeyT, ValueT>(container.begin(), container.end()) {}
+	                            ArrayMultiMap(std::initializer_list<value_type> l)	: ArrayMap<KeyT, ValueT>(l.begin(), l.end()) {}
+	template<class FwdIt>       ArrayMultiMap(FwdIt begin, FwdIt end)          		: ArrayMap<KeyT, ValueT>(begin, end) {}
+	                            ArrayMultiMap(std::multimap<KeyT, ValueT> &m) 		: ArrayMap<KeyT, ValueT>(m.begin(), m.end()) {}
+	                            ArrayMultiMap()       {}
+	~ArrayMultiMap()                                  { clear(); }
+
+	template<class TContainer>
+	ArrayMultiMap & operator=(const TContainer &rhs)  { replace(rhs.begin(), rhs.end()); return *this; }
+
+	size_t         count(const KeyT &key) const       { auto r = std::equal_range(base_type::begin(), base_type::end(), key, pair_sort_first_functor<value_type>()); return std::distance(r.first, r.second); }
+	iterator       lower_bound( const KeyT &key)      { return find(key); }
+	const_iterator lower_bound( const KeyT &key) const{ return find(key); }
+	iterator       upper_bound( const KeyT &key)      { auto u = std::upper_bound(base_type::begin(), base_type::end(), key, pair_sort_first_functor<value_type>()); return (u == base_type::end() || (u-1)->first != key) ? base_type::end() : u; }
+	const_iterator upper_bound( const KeyT &key) const{ auto u = std::upper_bound(base_type::begin(), base_type::end(), key, pair_sort_first_functor<value_type>()); return (u == base_type::end() || (u-1)->first != key) ? base_type::end() : u; }
+	std::pair<iterator, iterator>
+				   equal_range( const KeyT &key)      { return std::make_pair(lower_bound(key), upper_bound(key)); }
+	std::pair<const_iterator, const_iterator>
+				   equal_range( const KeyT &key) const{ return std::make_pair(lower_bound(key), upper_bound(key)); }
+
+};
 
 template <typename T>
 class ArraySet : public FixedArray<T>

--- a/ArrayTypes.h
+++ b/ArrayTypes.h
@@ -85,7 +85,6 @@ public:
 		}
 	}
 
-protected:
 	void clear()
 	{
 		if(m_begin)
@@ -139,7 +138,7 @@ public:
 	                            ArrayMap(std::initializer_list<value_type> l) : base_type(l.begin(), l.end())                          { std::sort(base_type::begin(), base_type::end()); }
 	template<class FwdIt>       ArrayMap(FwdIt begin, FwdIt end)              : base_type(begin, end, compute_fwd_it_dist(begin, end)) { std::sort(base_type::begin(), base_type::end()); }
 	                            ArrayMap(std::map<KeyT, ValueT> &m)           : base_type(m.begin(), m.end(), m.size())                { std::sort(base_type::begin(), base_type::end()); }
-
+	ArrayMap()                                        {}
 	~ArrayMap()                                       { base_type::clear(); }
 
 	template<class TContainer>
@@ -152,7 +151,7 @@ public:
 	const ValueT & operator[](const KeyT &key) const  { assert(find(key) != base_type::end()); return find(key)->second; }
 
 	template<class It>
-	void replace(It begin, It end) { base_type::replace(begin, end); std::sort(begin(), end()); }
+	void replace(It begin, It end) { base_type::replace(begin, end); std::sort(base_type::begin(), base_type::end()); }
 };
 
 

--- a/ArrayTypes.h
+++ b/ArrayTypes.h
@@ -37,6 +37,8 @@ public:
 	                            FixedArray(std::initializer_list<T> l)          : m_begin(nullptr), m_end(nullptr) { replace(l.begin(), l.end()); }
 	template<class FwdIt>       FixedArray(FwdIt begin, FwdIt end, size_t size) : m_begin(nullptr), m_end(nullptr) { replace(begin, end, size); }
 	template<class RndAccessIt> FixedArray(RndAccessIt begin, RndAccessIt end)  : m_begin(nullptr), m_end(nullptr) { replace(begin, end); }
+	                            FixedArray(                          )          : m_begin(nullptr), m_end(nullptr) {                              }
+
 
 	~FixedArray()                                 { clear(); }
 
@@ -53,7 +55,7 @@ public:
 	size_t size() const                           { return m_end - m_begin; }
 	bool   empty() const                          { return m_end == m_begin; }
 
-	template<class RndAccessIt> void replace(RndAccessIt begin, RndAccessIt end)              { replace(begin, end, end - begin); }
+	template<class RndAccessIt> void replace(RndAccessIt begin, RndAccessIt end)              { replace(begin, end, std::distance(begin, end)); }
 	template<class It>          void replace(It          begin, It          end, size_t size)
 	{
 		for(T * next = m_begin; next < m_end; ++next)

--- a/ArrayTypes.h
+++ b/ArrayTypes.h
@@ -19,7 +19,7 @@
 #include <utility> // for std::pair
 #include <initializer_list>
 
-namespace data_structure_benchmark {
+namespace FixedMaps {
 
 // NOTE: This is *not* a full implementation of the read-only portion of the std::vector API.
 //       If you drop it in to production code, you'll probably have to add stuff.

--- a/ArrayTypes.h
+++ b/ArrayTypes.h
@@ -73,7 +73,7 @@ public:
 			T * next = m_begin;
 			while(begin != end)
 			{
-				*next = std::move(*begin);
+				new (next) T(std::move(*begin));
 				++begin;
 				++next;
 			}

--- a/data_structure_benchmarks.cpp
+++ b/data_structure_benchmarks.cpp
@@ -53,7 +53,7 @@ const std::vector<int> & randomize_lookup_indices(size_t size);
 	template <typename Data> using SmallVec8    = llvm::SmallVector<Data, 8>;
 	template <typename Data> using SmallVec16   = llvm::SmallVector<Data, 16>;
 	template <typename Data> using SmallVec1024 = llvm::SmallVector<Data, 1024>;
-	template <typename Data> using FixedArray = data_structure_benchmark::FixedArray<Data>;
+	template <typename Data> using FixedArray = FixedMaps::FixedArray<Data>;
 
 	template<class ContainerT, class ValueT>
 	void BM_vector_emplace_back(benchmark::State &state) {
@@ -123,7 +123,7 @@ const std::vector<int> & randomize_lookup_indices(size_t size);
 	template <typename Data> using std_map = std::map<intptr_t, Data>;
 	template <typename Data> using std_unordered_map = std::unordered_map<intptr_t, Data>;
 	template <typename Data> using DenseMap = llvm::DenseMap<intptr_t, Data>;
-	template <typename Data> using ArrayMap = data_structure_benchmark::ArrayMap<intptr_t, Data>;
+	template <typename Data> using ArrayMap = FixedMaps::ArrayMap<intptr_t, Data>;
 
 	template<class ContainerT, class ValueT>
 	void BM_map_insert(benchmark::State &state) {
@@ -167,7 +167,7 @@ const std::vector<int> & randomize_lookup_indices(size_t size);
 #if BENCHMARK_SETS
 template <typename Data> using SmallSet8 = llvm::SmallSet<Data, 8>;
 template <typename Data> using SmallSet16 = llvm::SmallSet<Data, 16>;
-template <typename Data> using ArraySet = data_structure_benchmark::ArraySet<Data>;
+template <typename Data> using ArraySet = FixedMaps::ArraySet<Data>;
 
 template<class ContainerT, class ValueT>
 void BM_set_insert(benchmark::State &state) {


### PR DESCRIPTION
Using the move-assignment operator on an uninitialized object (memory on which no constructor has been called) is undefined. The move assignment operator could be freeing resources in the object that is moved to, but that object doesn't exist in the raw memory. 
std::uninitialized_move() could be used, if the compiler supports C++17. Otherwise, we must force the use of the move constructor rather than the move assignment operator. We do this by using placement new.