### PR TITLE
Update CMakeLists.txt to use find_package for benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,9 @@ add_executable(llvm_data_structure_benchmarks
 		data_structure_benchmarks.cpp
 		lib/llvm/support/Error.cpp)
 target_include_directories(llvm_data_structure_benchmarks SYSTEM PRIVATE
-		"/usr/local/Cellar/google-benchmark/1.3.0/include/" # Get this on Mac from $ brew install google-benchmark
 		"${CMAKE_CURRENT_SOURCE_DIR}/lib/llvm/include")
-find_library(GOOGLE_BENCHMARK benchmark)
-target_link_libraries(llvm_data_structure_benchmarks
-		${GOOGLE_BENCHMARK})
+find_package(benchmark REQUIRED)
+target_link_libraries(llvm_data_structure_benchmarks benchmark::benchmark)
 
 target_compile_options(llvm_data_structure_benchmarks PRIVATE
 		-march=haswell) # May want to try with -march=native as well


### PR DESCRIPTION
This is the approach suggested currently in https://github.com/google/benchmark?tab=readme-ov-file#usage-with-cmake